### PR TITLE
Wandering trader advancement changes

### DIFF
--- a/docs/en_us/features.md
+++ b/docs/en_us/features.md
@@ -402,12 +402,6 @@ there are a 10% chance for the pale oak tree to generate a creaking heart.
 
 ---
 
-##### Additional Tier 2 Trade: #####
-
-| Item        | Price | Input Item | Trades until disabled |
-|-------------|-------|------------|-----------------------|
-| Lava Bucket | 16    | Bucket     | 1                     |
-
 ### Carpet Features
 
 Default installation will also enable these `fabric-carpet` features.

--- a/src/main/resources/resourcepacks/skyblock/data/skyblock/advancement/progression/all_wandering_trader_trades.json
+++ b/src/main/resources/resourcepacks/skyblock/data/skyblock/advancement/progression/all_wandering_trader_trades.json
@@ -254,18 +254,6 @@
         ]
       }
     },
-    "has_pink_petals": {
-      "trigger": "minecraft:inventory_changed",
-      "conditions": {
-        "items": [
-          {
-            "items": [
-              "minecraft:pink_petals"
-            ]
-          }
-        ]
-      }
-    },
     "has_acacia_sapling": {
       "trigger": "minecraft:inventory_changed",
       "conditions": {
@@ -381,18 +369,6 @@
           {
             "items": [
               "minecraft:pale_moss_block"
-            ]
-          }
-        ]
-      }
-    },
-    "has_open_eyeblossom": {
-      "trigger": "minecraft:inventory_changed",
-      "conditions": {
-        "items": [
-          {
-            "items": [
-              "minecraft:open_eyeblossom"
             ]
           }
         ]

--- a/src/main/resources/resourcepacks/skyblock_acacia/data/skyblock/advancement/progression/all_wandering_trader_trades.json
+++ b/src/main/resources/resourcepacks/skyblock_acacia/data/skyblock/advancement/progression/all_wandering_trader_trades.json
@@ -254,18 +254,6 @@
         ]
       }
     },
-    "has_pink_petals": {
-      "trigger": "minecraft:inventory_changed",
-      "conditions": {
-        "items": [
-          {
-            "items": [
-              "minecraft:pink_petals"
-            ]
-          }
-        ]
-      }
-    },
     "has_acacia_sapling": {
       "trigger": "minecraft:inventory_changed",
       "conditions": {
@@ -381,18 +369,6 @@
           {
             "items": [
               "minecraft:pale_moss_block"
-            ]
-          }
-        ]
-      }
-    },
-    "has_open_eyeblossom": {
-      "trigger": "minecraft:inventory_changed",
-      "conditions": {
-        "items": [
-          {
-            "items": [
-              "minecraft:open_eyeblossom"
             ]
           }
         ]


### PR DESCRIPTION
Removed pink petals and open eyeblossom from the wandering trader advancement.